### PR TITLE
default worker config

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,8 +6,7 @@ on: push
 
 jobs:
   test:
-    # using `ubuntu-latest` does not support older OTP versions
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -15,25 +14,19 @@ jobs:
       fail-fast: false
       matrix:
         # https://repo.hex.pm/builds/elixir/builds.txt
-        elixir: [1.11.4, 1.12.3, 1.13.2, 1.14, 1.15]
-        otp: [21.x, 22.x, 23.x, 24.x, 25.x, 26.x]
+        elixir: [1.11, 1.12, 1.13, 1.14, 1.15]
+        otp: [24.x, 25.x, 26.x]
         exclude:
-          - elixir: 1.11.4
+          - elixir: 1.11
             otp: 25.x
-          - elixir: 1.12.3
-            otp: 21.x
-          - elixir: 1.12.3
+          - elixir: 1.11
+            otp: 26.x
+          - elixir: 1.12
             otp: 25.x
-          - elixir: 1.13.2
-            otp: 21.x
-          - elixir: 1.14
-            otp: 21.x
-          - elixir: 1.14
-            otp: 22.x
-          - elixir: 1.15
-            otp: 21.x
-          - elixir: 1.15
-            otp: 22.x
+          - elixir: 1.12
+            otp: 26.x
+          - elixir: 1.13
+            otp: 26.x
         include:
           - elixir: 1.14
             otp: 25.x

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
 
+# for vs code
+/.elixir_ls/
+
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can also change the provider on a per-call basis:
     # use the default provider
     {:error, nil} <- Geocoder.call(query),
     # use an alternative provider. If `key` is not specified here the globally defined key will be used.
-    {:error, nil} <- Geocoder.call(query, provider: Geocoder.Providers.OpenCageData, key: "123"),
+    {:error, nil} <- Geocoder.call(query, worker_config: [provider: Geocoder.Providers.OpenCageData, key: "123"]),
     do: {:error}
 ```
 
@@ -169,7 +169,7 @@ Right now, `:geocoder` supports three external providers (i.e. sources):
 
 To run the tests for these, and any future providers, you'll want to pass a `PROVIDER` environment variable as well as the `API_KEY`:
 
-```
+```shell
 PROVIDER=google API_KEY="mykey" mix test
 ```
 
@@ -181,8 +181,6 @@ The fake provider can be configured by adding a `:data` tuple to the configurati
 
 The keys of the data map must be in either [regex](https://hexdocs.pm/elixir/Regex.html) or
 [tuple](https://hexdocs.pm/elixir/Tuple.html) format (specifically a `{lat, lng}` style pair of floats).
-
-```elixir
 
 ```elixir
 [

--- a/lib/geocoder/worker.ex
+++ b/lib/geocoder/worker.ex
@@ -95,6 +95,7 @@ defmodule Geocoder.Worker do
     apply(provider, function, [params, provider_config])
   end
 
+  # when the provider is called directly and cache is not attempted
   defp run(function, params, false) do
     {provider, provider_config, store_module, store_name} = get_run_details(params)
 
@@ -118,8 +119,10 @@ defmodule Geocoder.Worker do
   end
 
   defp get_run_details(params) do
-    worker_config = params[:worker_config]
+    # we want to keep any worker_config params that were not overwritten
+    worker_config = Geocoder.Config.worker_config(params)
     provider = worker_config[:provider]
+
     store_module = params[:store_module]
     store_name = params[:store_config][:name]
 

--- a/mix.lock
+++ b/mix.lock
@@ -23,7 +23,7 @@
   "ordinal": {:hex, :ordinal, "0.2.0", "d3eda0cb04ee1f0ca0aae37bf2cf56c28adce345fe56a75659031b6068275191", [:mix], [], "hexpm", "defca8f10dee9f03a090ed929a595303252700a9a73096b6f2f8d88341690d65"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm", "dad79704ce5440f3d5a3681c8590b9dc25d1a561e8f5a9c995281012860901e3"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "towel": {:hex, :towel, "0.2.2", "327ac13601e363017dba42442e6783f7095c147fa68eb3c24c0fb50a10e7a6fc", [:mix], [], "hexpm", "a7b3d16a63f4ccdb66388f2cf61e6701bfc190e0f0afaefbf246c909263725c2"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},

--- a/test/geocoder/store_test.exs
+++ b/test/geocoder/store_test.exs
@@ -28,10 +28,17 @@ defmodule Geocoder.StoreTest do
     test "Store the location in state", %{pid: pid} do
       coord = belgium_coords()
 
+      erlang_version = :erlang.system_info(:otp_release) |> List.to_string()
+
+      # the key is different depending on the elixir version
+      key =
+        if Version.compare(erlang_version, "26.0") in [:eq, :gt],
+          do: "ZmxhbmRlcnNnaGVudGJlbGdpdW0=",
+          else: "Z2hlbnRiZWxnaXVtZmxhbmRlcnM="
+
       assert ^coord = Store.update(pid, coord)
 
-      assert {%{"Z2hlbnRiZWxnaXVtZmxhbmRlcnM=" => "u14ds6"}, %{"u14ds6" => ^coord},
-              [precision: 6]} = Store.state(pid)
+      assert {%{^key => "u14ds6"}, %{"u14ds6" => ^coord}, [precision: 6]} = Store.state(pid)
     end
   end
 


### PR DESCRIPTION
This was a tricky change for me to debug. Wanted to get your eyes on it before merging in:

- docs: update worker_config param for inline provider configuration
- dev: ignore elixir_ls for vs code users
- build: bump ssl_verify_fun so this runs on 1.15
- fix: inherit default worker_config when overwritting it
