### PR TITLE
update minmum support for the library

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,17 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         # https://repo.hex.pm/builds/elixir/builds.txt
-        elixir: [1.11, 1.12, 1.13, 1.14, 1.15]
+        elixir: [1.13, 1.14, 1.15]
         otp: [24.x, 25.x, 26.x]
         exclude:
-          - elixir: 1.11
-            otp: 25.x
-          - elixir: 1.11
-            otp: 26.x
-          - elixir: 1.12
-            otp: 25.x
-          - elixir: 1.12
-            otp: 26.x
           - elixir: 1.13
             otp: 26.x
         include:

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Geocoder.Mixfile do
     [
       app: :geocoder,
       version: @version,
-      elixir: "~> 1.10",
-      otp: "~> 21",
+      elixir: "~> 1.13",
+      otp: "~> 24",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Mix.exs said support 1.10 but Matrix do not test for it
Mix.exs said support OTP 21, 22 and 23 but Matrix do not test for it

While it might work, those versions are not considered maintained much per https://hexdocs.pm/elixir/1.12/compatibility-and-deprecations.html

even more so https://hexdocs.pm/elixir/1.16.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp

So proposing we bump a new version that allows to let the old stuff retire and force to a small set of version for a bit

what do you think?